### PR TITLE
Build script tweaks and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
-# ocs-build
-Scripts used to build and deploy the OCS.
+## OCS build and deployment scripts.
+
+This package consists of a selection of scripts used to build and deploy OCS from the OCS build machine.
+
+Details regarding the build machine, the contents of this package, and how to commence the deployment can be found in the SWG wiki at:
+http://swg.wikis-internal.gemini.edu/index.php/OCS_2_Build

--- a/common.sh
+++ b/common.sh
@@ -5,6 +5,8 @@ source genfuncs.sh
 source logging.sh
 source verfuncs.sh
 
+# This causes problems so unset.
+unset LC_CTYPE
 
 # Set up the requisite paths.
 DEV_BASE_PATH=`absPath ${DEV_BASE_PATH:-"$HOME/dev"}`


### PR DESCRIPTION
A few small changes to the build scripts:
1. Remove debugging output and comments.
2. Unset LC_CTYPE in common.sh as locale issues when building from the build machine caused svn to issue a warning on the ODB test servers, which caused the smartgcal servlet (as it uses svn) to fail.
3. Modified ssh code to start ODB test servers to run in background, since running in foreground caused the ssh command to never return and required a SIGINT for the build script to continue.
4. Increased server wait time from 20s to 60s to allow database more time to start up. We may want to increase this even higher if there turn out to be issues.
