### PR TITLE
Build script improvements

### DIFF
--- a/appfuncs.sh
+++ b/appfuncs.sh
@@ -2,9 +2,10 @@
 # Functions and definitions to work with the different applications for
 # the distribtuion.
 
-source common.sh
-source logging.sh
-source genfuncs.sh
+BASE_DIR=`dirname $0`
+source $BASE_DIR/common.sh
+source $BASE_DIR/logging.sh
+source $BASE_DIR/genfuncs.sh
 
 APP_OT=ot
 APP_QPT=qpt
@@ -69,11 +70,11 @@ function buildApp() {
 	logError "buildApp: no OCS base path specified."
 	return 1
     fi
-    local OLD_PATH="`pwd`"
-    cd "$OCS_BASE_PATH"
+
+    pushd "$OCS_BASE_PATH" > /dev/null
     if [[ $? -ne 0 ]]; then
-	logError "buildApp: could not cd to OCS base path: $OCS_BASE_PATH"
-	exit 1
+	logError "buildApp: could not access OCS base path: $OCS_BASE_PATH"
+	return 1
     fi
 
     local DISTS_ALL_VAR=DISTS_$APP[@]
@@ -106,7 +107,7 @@ function buildApp() {
 	fi
     done
 
-    cd "$OLD_PATH"
+    popd > /dev/null
     return 0
 }
 
@@ -133,7 +134,7 @@ function findDistFiles() {
     fi
     contains "$APP" "${APPS[@]}"
     if [[ $? -ne 0 ]]; then
-	logError "findDistFiles received illegal app name: $APP_NAME"
+	logError "findDistFiles received illegal app name: $APP"
 	return 1
     fi
 
@@ -150,7 +151,7 @@ function findDistFiles() {
     fi
 
     # Clear the array.
-    eval "DIST_FILES_${APP_NAME}=()"
+    eval "DIST_FILES_${APP}=()"
 
     # Separate processing for OCS/PIT apps and SPDB.
     if [[ "$APP" == "$APP_SPDB" ]]; then

--- a/common.sh
+++ b/common.sh
@@ -3,6 +3,7 @@
 
 BASE_DIR=`dirname $0`
 source $BASE_DIR/genfuncs.sh
+source $BASE_DIR/jdkfuncs.sh
 source $BASE_DIR/logging.sh
 source $BASE_DIR/verfuncs.sh
 

--- a/continuefuncs.sh
+++ b/continuefuncs.sh
@@ -1,0 +1,184 @@
+##!/usr/bin/bash
+# Functions that facilitate continuing the build process if it aborts early due to error.
+# We use exit for errors here instead of return, as this is tightly linked to the main
+# scripts and we don't want the main scripts to have to check error codes for each
+# function call.
+
+BASE_DIR=`dirname $0`
+source $BASE_DIR/common.sh
+source $BASE_DIR/logging.sh
+
+# ***********************************
+# ***** Config checks and setup *****
+# ***********************************
+function configSetup() {
+    # Make sure the VARIABLES or ARRAYS exist.
+    # If they don't, there isn't really anything we can do.
+    if [[ -z "$VARIABLES" && -z "$ARRAYS" ]]; then
+	echo "Error in `basename $0`: VARIABLES and / or ARRAYS must be set."
+	exit 1
+    fi
+
+    # Figure out the configuration file that records what step in the build was the last one executedo visit a
+    # and the build settings.
+    CONFIG_FILE=`eval "echo $0.cfg"`
+
+    # Initialize the step. If it exists, it will be set appropriately by configInterruptedHandler.
+    STEP=0
+
+    return 0
+}
+
+# *********************************************
+# ***** Config cleanup if script succeeds *****
+# *********************************************
+function configCleanup() {
+    deleteConfig
+    return 0
+}
+
+# *******************************************
+# ***** Check if the config file exists *****
+# *******************************************
+# Evaluates to a boolean expression that can be used as:
+# if configExists; then ...; else ...; fi
+function configExists() {
+    if [[ -f "$CONFIG_FILE" ]]; then
+	return 0
+    else
+	return 1
+    fi
+}
+
+# ***************************************************
+# ***** Determine if a step should be performed *****
+# ***************************************************
+# Evaluates to a boolean expression whether or not a step should be
+# performed. STEP should indicate the last step successfully performed
+# (with 0 indicating no steps have been performed) and the parameter
+# indicates the current step number.
+function shouldPerformStep() {
+    if [[ -z "$1" ]]; then
+	logError "shouldPerformStep requires the number of the current step."
+	exit 1
+    fi
+
+    # We perform the current step if it hasn't already been done.
+    if [[ "$STEP" -lt "$1" ]]; then
+	return 0
+    else
+	return 1
+    fi
+}
+
+# **************************
+# ***** Perform a step *****
+# **************************
+# Given a step number, checks to see if that step needs to be performed, and
+# if so, performs the function given as the second parameter with all pending arguments.
+# Then set STEP to indicate that the step was performed and rewrite the config file.
+function performStep() {
+    if [[ -z "$1" ]]; then
+	logError "performStep requires a step number for the first parameter."
+	exit 1
+    fi
+    if [[ -z "$2" ]]; then
+	logError "performStep requires a function for the second parameter."
+	exit 1
+    fi
+
+    if (shouldPerformStep $1); then
+	local ARGS=("$@")
+	eval "$2" "${ARGS[@]:2}"
+	if [[ $? -ne 0 ]]; then
+	    logError "Error in step $STEP."
+	    exit 1
+	fi
+
+	STEP=$1
+	writeConfig
+    fi
+    return 0
+}
+
+# ***************************************
+# ***** Interrupted script handling *****
+# ***************************************
+# This assumes that $CONFIG_FILE exists and demands the user continue or abort,
+# setting up the configuration variables necessary to pick up where we left off.
+# Parameter is $1, the first parameter to the script.
+function configInterruptedHandler() {
+    if [[ "$1" == "--continue" ]]; then
+	readConfig
+    elif [[ "$1" == "--abort" ]]; then
+	deleteConfig
+	echo "`basename $0` terminated. Manual cleanup may be necessary."
+	exit 0
+    else
+	echo "`basename $0` terminated before completing."
+	echo "Please either specify --abort or --continue to proceed."
+	exit 1
+    fi
+    return 0
+}
+
+# ********************************
+# ***** Read the config file *****
+# ********************************
+# Assumes that the config file exists.
+function readConfig() {
+    source "$CONFIG_FILE"
+    if [[ $? -ne 0 ]]; then
+	logError "Could not ready $CONFIG_FILE."
+	exit 1
+    fi
+    return 0
+}
+
+# *********************************
+# ***** Write the config file *****
+# *********************************
+function writeConfig() {
+    echo STEP="$STEP" > "$CONFIG_FILE"
+
+    local VARIABLE_NAME
+    for VARIABLE_NAME in ${VARIABLES[@]}; do
+	writeConfigVariable "$VARIABLE_NAME"
+    done
+
+    local ARRAY_NAME
+    for ARRAY_NAME in ${ARRAYS[@]}; do
+	writeConfigArray "$ARRAY_NAME"
+    done
+    return 0
+}
+
+# Write a line:
+# VARIABLE_NAME=VALUE
+# to the config file, where VARIABLE_NAME is the parameter.
+function writeConfigVariable() {
+    if [[ -n "${!1}" ]]; then
+	echo "$1"="${!1}" >> "$CONFIG_FILE"
+    fi
+    return 0
+}
+
+# Write a line:
+# ARRAY_NAME=(value1 value2 ...)
+# to the config file, where ARRAY_NAME is the parameter.
+function writeConfigArray() {
+    if [[ -n "${!1}" ]]; then
+	local ARRAYNAME=$1
+	eval local ARRAY=\( \${${ARRAYNAME}[@]} \)
+	echo "$ARRAYNAME"="(${ARRAY[@]})" >> "$CONFIG_FILE"
+    fi
+    return 0
+}
+
+# **********************************
+# ***** Delete the config file *****
+# **********************************
+function deleteConfig() {
+    rm -f "$CONFIG_FILE"
+    return 0
+}

--- a/jdkfuncs.sh
+++ b/jdkfuncs.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# This code taken from:
+# https://www.jayway.com/2014/01/15/how-to-switch-jdk-version-on-mac-os-x-maverick
+# It allows setting the JDK version to use in the current process.
+function setjdk() {
+    if [ $# -ne 0 ]; then
+	removeFromPath '/System/Library/Frameworks/JavaVM.framework/Home/bin'
+	if [ -n "${JAVA_HOME+x}" ]; then
+	    removeFromPath $JAVA_HOME
+	fi
+	export JAVA_HOME=`/usr/libexec/java_home -v $@`
+	export PATH=$JAVA_HOME/bin:$PATH
+    fi
+}
+
+function removeFromPath() {
+    export PATH=$(echo $PATH | sed -E -e "s;:$1;;" -e "s;$1:?;;")
+}

--- a/keysetup.exp
+++ b/keysetup.exp
@@ -19,8 +19,8 @@ proc checkPassword { password msg exitCode } {
 	exit $exitCode
     }
 }
-checkPassword $telopsPassword   "telops password must be filled out in keysetup.exp."  1
-checkPassword $softwarePassword "software password must be filled out in keysetup.exp" 2
+checkPassword $telopsPassword   "telops password must be filled out in keysetup.exp.\n"  1
+checkPassword $softwarePassword "software password must be filled out in keysetup.exp.\n" 2
 
 
 proc sshCopyID { username password server } {
@@ -28,9 +28,9 @@ proc sshCopyID { username password server } {
     spawn ssh-copy-id $username@$server
     expect {
 	timeout     { send_user "Failed to get password prompt.\n"; exit 3 }
-	eof         { send_user "ssh failure\n"; exit 4 }
+	eof         { send_user "SSH failure\n"; exit 4 }
 	"*password" { send "$password\r" }
-	"*system."  { send_user "ssh id is already configured.\n" }
+	"*system."  { send_user "SSH ID is already configured.\n" }
 	"Warning*"  { send_user "RSA host key differs from key for IP address. Please fix this and rerun.\n"; exit 5 }
     }
 }

--- a/keysetup.exp
+++ b/keysetup.exp
@@ -1,0 +1,43 @@
+#!/usr/bin/env expect
+
+# *** FILL OUT TELOPS PASSWORD ***
+set telopsUser "telops"
+set telopsPassword ""
+set telopsServers { "gsconfig" "gnconfig" "sbfcon02" "hbfcon03" }
+
+# *** FILL OUT SOFTWARE PASSWORD ***
+set softwareUser "software"
+set softwarePassword ""
+set softwareServers { "gsodbtest2" "gnodbtest2" "gsodb" "gnodb" }
+
+set timeout 30
+log_user 0
+
+proc checkPassword { password msg exitCode } {
+    if {$password eq ""} {
+	send_user $msg
+	exit $exitCode
+    }
+}
+checkPassword $telopsPassword   "telops password must be filled out in keysetup.exp."  1
+checkPassword $softwarePassword "software password must be filled out in keysetup.exp" 2
+
+
+proc sshCopyID { username password server } {
+    send_user "Attempting to set up key for ${username}@${server}...\n"
+    spawn ssh-copy-id $username@$server
+    expect {
+	timeout     { send_user "Failed to get password prompt.\n"; exit 3 }
+	eof         { send_user "ssh failure\n"; exit 4 }
+	"*password" { send "$password\r" }
+	"*system."  { send_user "ssh id is already configured.\n" }
+	"Warning*"  { send_user "RSA host key differs from key for IP address. Please fix this and rerun.\n"; exit 5 }
+    }
+}
+
+foreach server $telopsServers {
+    sshCopyID $telopsUser $telopsPassword $server
+}
+foreach server $softwareServers {
+    sshCopyID $softwareUser $softwarePassword $server
+}

--- a/logging.sh
+++ b/logging.sh
@@ -43,14 +43,16 @@ function colorPrint() {
     if [[ "$USE_COLOR" == "TRUE" ]]; then
 	printf "$COLOR_NONE"
     fi
+    return 0
 }
 
 # Header logging: if a second param is given, no leading newline.
 function logHeader() {
-    if [ -z "$2" ]; then
+    if [[ -z "$2" ]]; then
 	printf "\n"
     fi
     colorPrint "[ $1 ]\n" "$COLOR_HEADER"
+    return 0
 }
 
 # Internal function for printing out log categories.
@@ -58,21 +60,25 @@ function logCat() {
     printf "["
     colorPrint "$1" "$2"
     printf "]"
+    return 0
 }
 
 function logInfo() {
     logCat "info" "$COLOR_INFO"
     echo "  $@"
+    return 0
 }
 
 function logWarn() {
     logCat "warn" "$COLOR_WARN"
     echo "  $@"
+    return 0
 }
 
 function logError() {
     logCat "error" "$COLOR_ERROR"
     echo " $@"
+    return 0
 }
 
 # If the variable VERBOSE is set to TRUE, then output a message; otherwise do nothing.
@@ -81,6 +87,7 @@ function verbose() {
 	logCat "vinfo" "$COLOR_VINFO"
 	echo " $@"
     fi
+    return 0
 }
 
 # Run one of two commands depending on whether verbosity is selected.
@@ -91,4 +98,5 @@ function execVerbose() {
     else
 	eval "$2"
     fi
+    return $?
 }

--- a/odb_deploy.sh
+++ b/odb_deploy.sh
@@ -271,17 +271,12 @@ function processServer() {
     fi
 
     local SERVER_STEP=$(($SERVER_NUMBER * 6))
-    echo STEP="$STEP" SERVER_STEP="$SERVER_STEP" SERVER_NUMBER="$SERVER_NUMBER"
     performStep $(($SERVER_STEP + 6)) copyDist "$SERVER" "$DIST"
     performStep $(($SERVER_STEP + 7)) fetchLatestBackup "$SERVER" "$SOURCE_SERVER" "$MOUNT_POINT"
     performStep $(($SERVER_STEP + 8)) stopServer "$SERVER"
-    echo setupKeys
     performStep $(($SERVER_STEP + 9)) setupKeys "$SERVER"
-    echo startServer
     performStep $(($SERVER_STEP + 10)) startServer "$SERVER"
-    echo importXml
     performStep $(($SERVER_STEP + 11)) importXml "$SERVER"
-    echo done
     return 0
 }
 


### PR DESCRIPTION
This PR comprises major changes to the way that the build script works.

Smaller changes include:
1. Scripts can now be run anywhere instead of requiring the user to be in the ocs-build dir.
2. Lots of cleanup.
3. Java version is now set (OS X only: will fail on other platforms, but not terminate build).

Larger changes include:
1. Previously, if SSH IDs expired, the scripts would prompt a password, and this would generally cause timeout and failure. Now, SSH IDs are always set up at the beginning of the script.
2. Functionality to continue the build process has now been implemented, so if there is a failure, the build can recommence where it left off instead of having to start over from scratch.

This took longer and was more elaborate than expected between the remembering bash programming, writing the code, debugging, and testing. 😄 
